### PR TITLE
Add basic site settings tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ It provides a secure, standardized way for AI assistants to interact with WordPr
 
 ---
 
+## Site Settings Tools
+
+- **get-site-settings** – View WordPress site configuration and reading settings
+- **update-site-settings** – Update basic site configuration such as title, tagline, timezone, and front page behavior
+
+---
+
 ## Upcoming Tools
 
 ### Plugin Management
@@ -165,8 +172,6 @@ It provides a secure, standardized way for AI assistants to interact with WordPr
 
 #### Settings Management
 
-- **get-reading-settings** – View WordPress reading/display settings
-- **update-reading-settings** – Modify basic WordPress reading settings
 - **manage-comment-settings** – Manage comment-related settings (Planned but not registered)
 - **export-settings** – Export current WordPress site settings (Planned)
 - **import-settings** – Import WordPress site settings from a file (Planned)

--- a/build/index.js
+++ b/build/index.js
@@ -7,6 +7,7 @@ import { registerPostTools } from "./tools/postTools.js";
 import { registerTaxonomyTools } from "./tools/taxonomyTools.js";
 import { registerMediaTools } from "./tools/mediaTools.js";
 import { registerUserTools } from "./tools/userTools.js";
+import { registerSettingsTools } from "./tools/settingsTools.js";
 // Import WordPress API functions for authentication
 import { setWordPressConfig, testSiteConnection, testAuthentication, } from "./wordpress/api.js";
 // Create the MCP server instance with metadata
@@ -87,6 +88,7 @@ registerPostTools(server);
 registerMediaTools(server);
 registerTaxonomyTools(server);
 registerUserTools(server);
+registerSettingsTools(server);
 // registerSystemTools(server);
 // ============================================
 // SERVER STARTUP

--- a/build/tools/settingsTools.js
+++ b/build/tools/settingsTools.js
@@ -1,0 +1,113 @@
+import { z } from "zod";
+import { getSiteSettings, updateSiteSettings } from "../wordpress/api.js";
+/**
+ * Register site settings tools with the MCP server
+ */
+export function registerSettingsTools(server) {
+    server.tool("get-site-settings", "Get the current WordPress site settings", {}, async () => {
+        try {
+            const result = await getSiteSettings();
+            if (!result.success || !result.settings) {
+                return {
+                    content: [{
+                            type: "text",
+                            text: `Failed to get site settings: ${JSON.stringify(result.error)}`
+                        }],
+                    isError: true
+                };
+            }
+            const settings = result.settings;
+            const summary = [
+                `Title: ${settings.title ?? "unknown"}`,
+                `Description: ${settings.description ?? "unknown"}`,
+                `Timezone: ${settings.timezone ?? "unknown"}`,
+                `Language: ${settings.language ?? "unknown"}`,
+                `Posts per page: ${settings.posts_per_page ?? "unknown"}`,
+                `Default category: ${settings.default_category ?? "unknown"}`,
+                `Front page: ${settings.show_on_front ?? "unknown"}`,
+                `Comment status: ${settings.default_comment_status ?? "unknown"}`,
+                `Ping status: ${settings.default_ping_status ?? "unknown"}`
+            ].join("\n");
+            return {
+                content: [{
+                        type: "text",
+                        text: `WordPress site settings:\n\n${summary}`
+                    }]
+            };
+        }
+        catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            console.error("Error executing get-site-settings tool:", error);
+            return {
+                content: [{
+                        type: "text",
+                        text: `Error getting site settings: ${errorMessage}`
+                    }],
+                isError: true
+            };
+        }
+    });
+    server.tool("update-site-settings", "Update basic WordPress site settings", {
+        title: z.string().optional().describe("Site title"),
+        description: z.string().optional().describe("Site tagline"),
+        timezone: z.string().optional().describe("Timezone string, for example 'Africa/Nairobi'"),
+        language: z.string().optional().describe("WordPress locale code"),
+        postsPerPage: z.number().int().positive().max(100).optional().describe("Number of posts shown per page"),
+        defaultCategory: z.number().int().positive().optional().describe("Default post category ID"),
+        defaultPostFormat: z.string().optional().describe("Default post format"),
+        showOnFront: z.enum(["posts", "page"]).optional().describe("What to show on the front page"),
+        pageOnFront: z.number().int().positive().optional().describe("Page ID to use as the front page"),
+        pageForPosts: z.number().int().positive().optional().describe("Page ID to use for posts page"),
+        defaultPingStatus: z.enum(["open", "closed"]).optional().describe("Default pingback/trackback status"),
+        defaultCommentStatus: z.enum(["open", "closed"]).optional().describe("Default comment status"),
+        useSmilies: z.boolean().optional().describe("Convert emoticons to graphics"),
+        siteLogo: z.number().int().positive().optional().describe("Media ID for the site logo"),
+        siteIcon: z.number().int().positive().optional().describe("Media ID for the site icon")
+    }, async ({ title, description, timezone, language, postsPerPage, defaultCategory, defaultPostFormat, showOnFront, pageOnFront, pageForPosts, defaultPingStatus, defaultCommentStatus, useSmilies, siteLogo, siteIcon }) => {
+        try {
+            const result = await updateSiteSettings({
+                title,
+                description,
+                timezone,
+                language,
+                posts_per_page: postsPerPage,
+                default_category: defaultCategory,
+                default_post_format: defaultPostFormat,
+                show_on_front: showOnFront,
+                page_on_front: pageOnFront,
+                page_for_posts: pageForPosts,
+                default_ping_status: defaultPingStatus,
+                default_comment_status: defaultCommentStatus,
+                use_smilies: useSmilies,
+                site_logo: siteLogo,
+                site_icon: siteIcon
+            });
+            if (!result.success || !result.settings) {
+                return {
+                    content: [{
+                            type: "text",
+                            text: `Failed to update site settings: ${JSON.stringify(result.error)}`
+                        }],
+                    isError: true
+                };
+            }
+            return {
+                content: [{
+                        type: "text",
+                        text: `Site settings updated successfully.\n\nTitle: ${result.settings.title ?? "unknown"}\nDescription: ${result.settings.description ?? "unknown"}\nTimezone: ${result.settings.timezone ?? "unknown"}`
+                    }]
+            };
+        }
+        catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            console.error("Error executing update-site-settings tool:", error);
+            return {
+                content: [{
+                        type: "text",
+                        text: `Error updating site settings: ${errorMessage}`
+                    }],
+                isError: true
+            };
+        }
+    });
+}

--- a/build/wordpress/api.js
+++ b/build/wordpress/api.js
@@ -207,6 +207,48 @@ export async function deletePost(postId, force = false) {
         };
     }
 }
+export async function getSiteSettings() {
+    try {
+        if (!wpConfig.siteUrl)
+            throw new Error('WordPress site URL not configured');
+        if (!wpConfig.isAuthenticated)
+            throw new Error('Not authenticated');
+        const authHeader = await getAuthHeader();
+        const response = await axios.get(`${wpConfig.siteUrl}/wp-json/wp/v2/settings`, { headers: { 'Authorization': authHeader } });
+        return {
+            success: true,
+            settings: response.data
+        };
+    }
+    catch (error) {
+        console.error('Error getting site settings:', error);
+        return {
+            success: false,
+            error: error instanceof Error ? formatErrorResponse(error) : 'Unknown error'
+        };
+    }
+}
+export async function updateSiteSettings(updates) {
+    try {
+        if (!wpConfig.siteUrl)
+            throw new Error('WordPress site URL not configured');
+        if (!wpConfig.isAuthenticated)
+            throw new Error('Not authenticated');
+        const authHeader = await getAuthHeader();
+        const response = await axios.post(`${wpConfig.siteUrl}/wp-json/wp/v2/settings`, updates, { headers: { 'Authorization': authHeader, 'Content-Type': 'application/json' } });
+        return {
+            success: true,
+            settings: response.data
+        };
+    }
+    catch (error) {
+        console.error('Error updating site settings:', error);
+        return {
+            success: false,
+            error: error instanceof Error ? formatErrorResponse(error) : 'Unknown error'
+        };
+    }
+}
 export async function getPost(postId, includeRevisions = false) {
     try {
         if (!wpConfig.siteUrl)

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { registerPostTools } from "./tools/postTools.js";
 import { registerTaxonomyTools } from "./tools/taxonomyTools.js"; 
 import { registerMediaTools } from "./tools/mediaTools.js";
 import { registerUserTools } from "./tools/userTools.js";
+import { registerSettingsTools } from "./tools/settingsTools.js";
 
 
 // Import WordPress API functions for authentication
@@ -112,6 +113,7 @@ server.tool(
   registerMediaTools(server);
   registerTaxonomyTools(server);
   registerUserTools(server);
+  registerSettingsTools(server);
   // registerSystemTools(server);
 
 // ============================================

--- a/src/tools/settingsTools.ts
+++ b/src/tools/settingsTools.ts
@@ -1,0 +1,150 @@
+// src/tools/settingsTools.ts
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import {
+  getSiteSettings,
+  updateSiteSettings
+} from "../wordpress/api.js";
+
+/**
+ * Register site settings tools with the MCP server
+ */
+export function registerSettingsTools(server: McpServer) {
+  server.tool(
+    "get-site-settings",
+    "Get the current WordPress site settings",
+    {},
+    async () => {
+      try {
+        const result = await getSiteSettings();
+
+        if (!result.success || !result.settings) {
+          return {
+            content: [{
+              type: "text",
+              text: `Failed to get site settings: ${JSON.stringify(result.error)}`
+            }],
+            isError: true
+          };
+        }
+
+        const settings = result.settings;
+        const summary = [
+          `Title: ${settings.title ?? "unknown"}`,
+          `Description: ${settings.description ?? "unknown"}`,
+          `Timezone: ${settings.timezone ?? "unknown"}`,
+          `Language: ${settings.language ?? "unknown"}`,
+          `Posts per page: ${settings.posts_per_page ?? "unknown"}`,
+          `Default category: ${settings.default_category ?? "unknown"}`,
+          `Front page: ${settings.show_on_front ?? "unknown"}`,
+          `Comment status: ${settings.default_comment_status ?? "unknown"}`,
+          `Ping status: ${settings.default_ping_status ?? "unknown"}`
+        ].join("\n");
+
+        return {
+          content: [{
+            type: "text",
+            text: `WordPress site settings:\n\n${summary}`
+          }]
+        };
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        console.error("Error executing get-site-settings tool:", error);
+        return {
+          content: [{
+            type: "text",
+            text: `Error getting site settings: ${errorMessage}`
+          }],
+          isError: true
+        };
+      }
+    }
+  );
+
+  server.tool(
+    "update-site-settings",
+    "Update basic WordPress site settings",
+    {
+      title: z.string().optional().describe("Site title"),
+      description: z.string().optional().describe("Site tagline"),
+      timezone: z.string().optional().describe("Timezone string, for example 'Africa/Nairobi'"),
+      language: z.string().optional().describe("WordPress locale code"),
+      postsPerPage: z.number().int().positive().max(100).optional().describe("Number of posts shown per page"),
+      defaultCategory: z.number().int().positive().optional().describe("Default post category ID"),
+      defaultPostFormat: z.string().optional().describe("Default post format"),
+      showOnFront: z.enum(["posts", "page"]).optional().describe("What to show on the front page"),
+      pageOnFront: z.number().int().positive().optional().describe("Page ID to use as the front page"),
+      pageForPosts: z.number().int().positive().optional().describe("Page ID to use for posts page"),
+      defaultPingStatus: z.enum(["open", "closed"]).optional().describe("Default pingback/trackback status"),
+      defaultCommentStatus: z.enum(["open", "closed"]).optional().describe("Default comment status"),
+      useSmilies: z.boolean().optional().describe("Convert emoticons to graphics"),
+      siteLogo: z.number().int().positive().optional().describe("Media ID for the site logo"),
+      siteIcon: z.number().int().positive().optional().describe("Media ID for the site icon")
+    },
+    async ({
+      title,
+      description,
+      timezone,
+      language,
+      postsPerPage,
+      defaultCategory,
+      defaultPostFormat,
+      showOnFront,
+      pageOnFront,
+      pageForPosts,
+      defaultPingStatus,
+      defaultCommentStatus,
+      useSmilies,
+      siteLogo,
+      siteIcon
+    }) => {
+      try {
+        const result = await updateSiteSettings({
+          title,
+          description,
+          timezone,
+          language,
+          posts_per_page: postsPerPage,
+          default_category: defaultCategory,
+          default_post_format: defaultPostFormat,
+          show_on_front: showOnFront,
+          page_on_front: pageOnFront,
+          page_for_posts: pageForPosts,
+          default_ping_status: defaultPingStatus,
+          default_comment_status: defaultCommentStatus,
+          use_smilies: useSmilies,
+          site_logo: siteLogo,
+          site_icon: siteIcon
+        });
+
+        if (!result.success || !result.settings) {
+          return {
+            content: [{
+              type: "text",
+              text: `Failed to update site settings: ${JSON.stringify(result.error)}`
+            }],
+            isError: true
+          };
+        }
+
+        return {
+          content: [{
+            type: "text",
+            text: `Site settings updated successfully.\n\nTitle: ${result.settings.title ?? "unknown"}\nDescription: ${result.settings.description ?? "unknown"}\nTimezone: ${result.settings.timezone ?? "unknown"}`
+          }]
+        };
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        console.error("Error executing update-site-settings tool:", error);
+        return {
+          content: [{
+            type: "text",
+            text: `Error updating site settings: ${errorMessage}`
+          }],
+          isError: true
+        };
+      }
+    }
+  );
+}

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -81,6 +81,48 @@ export interface WPDeleteResponse {
   previous: any;
 }
 
+export interface WPSiteSettings {
+  title?: string;
+  description?: string;
+  timezone?: string;
+  date_format?: string;
+  time_format?: string;
+  start_of_week?: number;
+  language?: string;
+  use_smilies?: boolean;
+  default_category?: number;
+  default_post_format?: string;
+  posts_per_page?: number;
+  show_on_front?: string;
+  page_on_front?: number;
+  page_for_posts?: number;
+  default_ping_status?: "open" | "closed";
+  default_comment_status?: "open" | "closed";
+  site_logo?: number;
+  site_icon?: number;
+}
+
+export interface UpdateSiteSettingsData {
+  title?: string;
+  description?: string;
+  timezone?: string;
+  date_format?: string;
+  time_format?: string;
+  start_of_week?: number;
+  language?: string;
+  use_smilies?: boolean;
+  default_category?: number;
+  default_post_format?: string;
+  posts_per_page?: number;
+  show_on_front?: string;
+  page_on_front?: number;
+  page_for_posts?: number;
+  default_ping_status?: "open" | "closed";
+  default_comment_status?: "open" | "closed";
+  site_logo?: number;
+  site_icon?: number;
+}
+
 export interface WPTaxonomy {
   name: string;
   label: string;

--- a/src/wordpress/api.ts
+++ b/src/wordpress/api.ts
@@ -17,6 +17,8 @@ import {
   ListPostsOptions,
   WPPostDetailed,
   WPDeleteResponse,
+  WPSiteSettings,
+  UpdateSiteSettingsData,
   WPTaxonomy,
   WPUser,
   WPRole,
@@ -306,6 +308,57 @@ export async function deletePost(
     };
   } catch (error: unknown) {
     console.error('Error deleting post:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? formatErrorResponse(error) : 'Unknown error'
+    };
+  }
+}
+
+export async function getSiteSettings(): Promise<{ success: boolean; settings?: WPSiteSettings; error?: any }> {
+  try {
+    if (!wpConfig.siteUrl) throw new Error('WordPress site URL not configured');
+    if (!wpConfig.isAuthenticated) throw new Error('Not authenticated');
+
+    const authHeader = await getAuthHeader();
+    const response = await axios.get<WPSiteSettings>(
+      `${wpConfig.siteUrl}/wp-json/wp/v2/settings`,
+      { headers: { 'Authorization': authHeader } }
+    );
+
+    return {
+      success: true,
+      settings: response.data
+    };
+  } catch (error: unknown) {
+    console.error('Error getting site settings:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? formatErrorResponse(error) : 'Unknown error'
+    };
+  }
+}
+
+export async function updateSiteSettings(
+  updates: UpdateSiteSettingsData
+): Promise<{ success: boolean; settings?: WPSiteSettings; error?: any }> {
+  try {
+    if (!wpConfig.siteUrl) throw new Error('WordPress site URL not configured');
+    if (!wpConfig.isAuthenticated) throw new Error('Not authenticated');
+
+    const authHeader = await getAuthHeader();
+    const response = await axios.post<WPSiteSettings>(
+      `${wpConfig.siteUrl}/wp-json/wp/v2/settings`,
+      updates,
+      { headers: { 'Authorization': authHeader, 'Content-Type': 'application/json' } }
+    );
+
+    return {
+      success: true,
+      settings: response.data
+    };
+  } catch (error: unknown) {
+    console.error('Error updating site settings:', error);
     return {
       success: false,
       error: error instanceof Error ? formatErrorResponse(error) : 'Unknown error'


### PR DESCRIPTION
## Summary
- add get-site-settings and update-site-settings tools for the WordPress /wp/v2/settings endpoint
- wire the new tools into the MCP server bootstrap
- update the README so the new backend config surface is documented

## Verification
- npm test
- npm run build
- npm audit

This is the first concrete backend configuration step from the open feature request.