### PR TITLE
Add plugin listing tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,16 @@ It provides a secure, standardized way for AI assistants to interact with WordPr
 
 ---
 
+## Plugin Management Tools
+
+- **list-plugins** – List installed WordPress plugins with activation status
+
+---
+
 ## Upcoming Tools
 
 ### Plugin Management
 
-- **list-plugins** – List all WordPress plugins with their activation status
 - **install-plugin** – Install a plugin from the WordPress.org repository
 - **toggle-plugin** – Activate or deactivate a WordPress plugin
 - **update-plugin** – Update a WordPress plugin to its latest version

--- a/build/index.js
+++ b/build/index.js
@@ -8,6 +8,7 @@ import { registerTaxonomyTools } from "./tools/taxonomyTools.js";
 import { registerMediaTools } from "./tools/mediaTools.js";
 import { registerUserTools } from "./tools/userTools.js";
 import { registerSettingsTools } from "./tools/settingsTools.js";
+import { registerPluginTools } from "./tools/pluginTools.js";
 // Import WordPress API functions for authentication
 import { setWordPressConfig, testSiteConnection, testAuthentication, } from "./wordpress/api.js";
 // Create the MCP server instance with metadata
@@ -89,6 +90,7 @@ registerMediaTools(server);
 registerTaxonomyTools(server);
 registerUserTools(server);
 registerSettingsTools(server);
+registerPluginTools(server);
 // registerSystemTools(server);
 // ============================================
 // SERVER STARTUP

--- a/build/tools/pluginTools.js
+++ b/build/tools/pluginTools.js
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import { listPlugins } from "../wordpress/api.js";
+/**
+ * Register plugin management tools with the MCP server
+ */
+export function registerPluginTools(server) {
+    server.tool("list-plugins", "List installed WordPress plugins with activation status", {
+        page: z.number().default(1).describe("Page number (default: 1)"),
+        perPage: z.number().max(100).default(20).describe("Plugins per page (max: 100)"),
+        search: z.string().optional().describe("Search plugins by name or plugin file"),
+        status: z.enum(["inactive", "active"]).optional().describe("Filter by plugin status"),
+        context: z.enum(["view", "embed", "edit"]).default("view").describe("Response context")
+    }, async ({ page, perPage, search, status, context }) => {
+        try {
+            const result = await listPlugins({ page, perPage, search, status, context });
+            if (!result.success) {
+                return {
+                    content: [{
+                            type: "text",
+                            text: `Failed to list plugins: ${JSON.stringify(result.error)}`
+                        }],
+                    isError: true
+                };
+            }
+            const plugins = result.plugins?.map((plugin) => `- ${plugin.name} (${plugin.plugin})\n  Status: ${plugin.status}\n  Version: ${plugin.version}\n  Author: ${plugin.author}\n  Description: ${plugin.description}`).join("\n") || "No plugins found.";
+            return {
+                content: [{
+                        type: "text",
+                        text: `WordPress plugins:\n\n${plugins}\n\nTotal plugins: ${result.totalPlugins ?? 0}\nTotal pages: ${result.totalPages ?? 1}`
+                    }]
+            };
+        }
+        catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            console.error("Error listing plugins:", error);
+            return {
+                content: [{
+                        type: "text",
+                        text: `Error listing plugins: ${errorMessage}`
+                    }],
+                isError: true
+            };
+        }
+    });
+}

--- a/build/wordpress/api.js
+++ b/build/wordpress/api.js
@@ -207,6 +207,55 @@ export async function deletePost(postId, force = false) {
         };
     }
 }
+export async function listPlugins(options = {}) {
+    try {
+        if (!wpConfig.siteUrl)
+            throw new Error('WordPress site URL not configured');
+        if (!wpConfig.isAuthenticated)
+            throw new Error('Not authenticated');
+        const authHeader = await getAuthHeader();
+        const params = new URLSearchParams();
+        if (options.page)
+            params.append('page', options.page.toString());
+        if (options.perPage)
+            params.append('per_page', options.perPage.toString());
+        if (options.search)
+            params.append('search', options.search);
+        if (options.status)
+            params.append('status', options.status);
+        if (options.context)
+            params.append('context', options.context);
+        const response = await axios.get(`${wpConfig.siteUrl}/wp-json/wp/v2/plugins?${params.toString()}`, { headers: { 'Authorization': authHeader } });
+        const totalPages = parseInt(response.headers['x-wp-totalpages'] || '1');
+        const totalPlugins = parseInt(response.headers['x-wp-total'] || '0');
+        return {
+            success: true,
+            plugins: response.data.map(plugin => ({
+                plugin: plugin.plugin,
+                status: plugin.status,
+                name: plugin.name,
+                pluginUri: plugin.plugin_uri,
+                author: typeof plugin.author === 'string' ? plugin.author : plugin.author?.name || '',
+                authorUri: plugin.author_uri,
+                description: typeof plugin.description === 'string' ? plugin.description : plugin.description?.rendered || plugin.description?.raw || '',
+                version: plugin.version,
+                networkOnly: plugin.network_only,
+                requiresWp: plugin.requires_wp,
+                requiresPhp: plugin.requires_php,
+                textdomain: plugin.textdomain
+            })),
+            totalPages,
+            totalPlugins
+        };
+    }
+    catch (error) {
+        console.error('Error listing plugins:', error);
+        return {
+            success: false,
+            error: error instanceof Error ? formatErrorResponse(error) : 'Unknown error'
+        };
+    }
+}
 export async function getSiteSettings() {
     try {
         if (!wpConfig.siteUrl)

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { registerTaxonomyTools } from "./tools/taxonomyTools.js";
 import { registerMediaTools } from "./tools/mediaTools.js";
 import { registerUserTools } from "./tools/userTools.js";
 import { registerSettingsTools } from "./tools/settingsTools.js";
+import { registerPluginTools } from "./tools/pluginTools.js";
 
 
 // Import WordPress API functions for authentication
@@ -114,6 +115,7 @@ server.tool(
   registerTaxonomyTools(server);
   registerUserTools(server);
   registerSettingsTools(server);
+  registerPluginTools(server);
   // registerSystemTools(server);
 
 // ============================================

--- a/src/tools/pluginTools.ts
+++ b/src/tools/pluginTools.ts
@@ -1,0 +1,59 @@
+// src/tools/pluginTools.ts
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { listPlugins } from "../wordpress/api.js";
+import { WPPlugin } from "../types/interfaces.js";
+
+/**
+ * Register plugin management tools with the MCP server
+ */
+export function registerPluginTools(server: McpServer) {
+  server.tool(
+    "list-plugins",
+    "List installed WordPress plugins with activation status",
+    {
+      page: z.number().default(1).describe("Page number (default: 1)"),
+      perPage: z.number().max(100).default(20).describe("Plugins per page (max: 100)"),
+      search: z.string().optional().describe("Search plugins by name or plugin file"),
+      status: z.enum(["inactive", "active"]).optional().describe("Filter by plugin status"),
+      context: z.enum(["view", "embed", "edit"]).default("view").describe("Response context")
+    },
+    async ({ page, perPage, search, status, context }) => {
+      try {
+        const result = await listPlugins({ page, perPage, search, status, context });
+
+        if (!result.success) {
+          return {
+            content: [{
+              type: "text",
+              text: `Failed to list plugins: ${JSON.stringify(result.error)}`
+            }],
+            isError: true
+          };
+        }
+
+        const plugins = result.plugins?.map((plugin: WPPlugin) =>
+          `- ${plugin.name} (${plugin.plugin})\n  Status: ${plugin.status}\n  Version: ${plugin.version}\n  Author: ${plugin.author}\n  Description: ${plugin.description}`
+        ).join("\n") || "No plugins found.";
+
+        return {
+          content: [{
+            type: "text",
+            text: `WordPress plugins:\n\n${plugins}\n\nTotal plugins: ${result.totalPlugins ?? 0}\nTotal pages: ${result.totalPages ?? 1}`
+          }]
+        };
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        console.error("Error listing plugins:", error);
+        return {
+          content: [{
+            type: "text",
+            text: `Error listing plugins: ${errorMessage}`
+          }],
+          isError: true
+        };
+      }
+    }
+  );
+}

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -81,6 +81,36 @@ export interface WPDeleteResponse {
   previous: any;
 }
 
+export interface WPPluginResponse {
+  plugin: string;
+  status: "inactive" | "active";
+  name: string;
+  plugin_uri: string;
+  author: string | { name?: string; url?: string };
+  author_uri: string;
+  description: string | { raw?: string; rendered?: string; protected?: boolean };
+  version: string;
+  network_only: boolean;
+  requires_wp: string;
+  requires_php: string;
+  textdomain: string;
+}
+
+export interface WPPlugin {
+  plugin: string;
+  status: "inactive" | "active";
+  name: string;
+  pluginUri: string;
+  author: string;
+  authorUri: string;
+  description: string;
+  version: string;
+  networkOnly: boolean;
+  requiresWp: string;
+  requiresPhp: string;
+  textdomain: string;
+}
+
 export interface WPSiteSettings {
   title?: string;
   description?: string;

--- a/src/wordpress/api.ts
+++ b/src/wordpress/api.ts
@@ -17,6 +17,8 @@ import {
   ListPostsOptions,
   WPPostDetailed,
   WPDeleteResponse,
+  WPPluginResponse,
+  WPPlugin,
   WPSiteSettings,
   UpdateSiteSettingsData,
   WPTaxonomy,
@@ -308,6 +310,62 @@ export async function deletePost(
     };
   } catch (error: unknown) {
     console.error('Error deleting post:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? formatErrorResponse(error) : 'Unknown error'
+    };
+  }
+}
+
+export async function listPlugins(options: {
+  page?: number;
+  perPage?: number;
+  search?: string;
+  status?: "inactive" | "active";
+  context?: "view" | "embed" | "edit";
+} = {}): Promise<{ success: boolean; plugins?: WPPlugin[]; totalPages?: number; totalPlugins?: number; error?: any }> {
+  try {
+    if (!wpConfig.siteUrl) throw new Error('WordPress site URL not configured');
+    if (!wpConfig.isAuthenticated) throw new Error('Not authenticated');
+
+    const authHeader = await getAuthHeader();
+    const params = new URLSearchParams();
+
+    if (options.page) params.append('page', options.page.toString());
+    if (options.perPage) params.append('per_page', options.perPage.toString());
+    if (options.search) params.append('search', options.search);
+    if (options.status) params.append('status', options.status);
+    if (options.context) params.append('context', options.context);
+
+    const response = await axios.get<WPPluginResponse[]>(
+      `${wpConfig.siteUrl}/wp-json/wp/v2/plugins?${params.toString()}`,
+      { headers: { 'Authorization': authHeader } }
+    );
+
+    const totalPages = parseInt(response.headers['x-wp-totalpages'] || '1');
+    const totalPlugins = parseInt(response.headers['x-wp-total'] || '0');
+
+    return {
+      success: true,
+      plugins: response.data.map(plugin => ({
+        plugin: plugin.plugin,
+        status: plugin.status,
+        name: plugin.name,
+        pluginUri: plugin.plugin_uri,
+        author: typeof plugin.author === 'string' ? plugin.author : plugin.author?.name || '',
+        authorUri: plugin.author_uri,
+        description: typeof plugin.description === 'string' ? plugin.description : plugin.description?.rendered || plugin.description?.raw || '',
+        version: plugin.version,
+        networkOnly: plugin.network_only,
+        requiresWp: plugin.requires_wp,
+        requiresPhp: plugin.requires_php,
+        textdomain: plugin.textdomain
+      })),
+      totalPages,
+      totalPlugins
+    };
+  } catch (error: unknown) {
+    console.error('Error listing plugins:', error);
     return {
       success: false,
       error: error instanceof Error ? formatErrorResponse(error) : 'Unknown error'


### PR DESCRIPTION
## Summary
- add list-plugins MCP tool for the WordPress /wp/v2/plugins endpoint
- add typed plugin response models and an API wrapper for plugin listing
- register the new plugin tool in the MCP server bootstrap
- update the README so plugin listing is documented as an implemented tool

## Verification
- npm test
- npm run build
- npm audit

Source used for the endpoint shape: WordPress REST API plugin reference: https://developer.wordpress.org/rest-api/reference/plugins/